### PR TITLE
feat: refactor settingsview

### DIFF
--- a/X3Fuse/MenuCommands.swift
+++ b/X3Fuse/MenuCommands.swift
@@ -46,13 +46,6 @@ struct MenuCommands: Commands {
         openFilePanel()
       }
       .keyboardShortcut("o", modifiers: .command)
-
-      Divider()
-
-      Button(LocalizationService.menuFileSettings) {
-        NotificationCenter.default.post(name: NSNotification.Name("ShowSettings"), object: nil)
-      }
-      .keyboardShortcut(",", modifiers: .command)
     }
 
     // Edit menu additions

--- a/X3Fuse/Views/ContentView.swift
+++ b/X3Fuse/Views/ContentView.swift
@@ -15,7 +15,6 @@ struct ContentView: View {
   @State private var fileProcessor = FileProcessor.shared
   @State private var logger = LoggingService.shared
 
-  @State private var showingSettings = false
   @State private var selectedFile: X3FFile?
   @State private var setupIssues: [String] = []
   @State private var selectedFileIDs = Set<X3FFile.ID>()
@@ -81,11 +80,6 @@ struct ContentView: View {
     }
     .onDisappear {
       removeNotificationObservers()
-    }
-    .sheet(isPresented: $showingSettings) {
-      SettingsView()
-        .frame(idealWidth: 450, maxWidth: 450, idealHeight: 700, maxHeight: .infinity)
-        .fixedSize(horizontal: true, vertical: false)
     }
     .alert(LocalizationService.alertSetupIssuesTitle, isPresented: .constant(!setupIssues.isEmpty)) {
       Button(LocalizationService.buttonOK) {
@@ -210,7 +204,7 @@ struct ContentView: View {
 
       Spacer()
 
-      Button(action: { showingSettings = true }) {
+      SettingsLink {
         Image(systemName: "gearshape")
       }
       .buttonStyle(.bordered)
@@ -367,13 +361,8 @@ struct ContentView: View {
       self.handleDeselectAll()
     }
 
-    NotificationCenter.default.addObserver(
-      forName: NSNotification.Name("ShowSettings"),
-      object: nil,
-      queue: .main
-    ) { _ in
-      self.showingSettings = true
-    }
+    // Note: ShowSettings notification is not needed when using SettingsLink
+    // The menu command will automatically open the Settings scene
   }
 
   private func removeNotificationObservers() {

--- a/X3Fuse/Views/SettingsView.swift
+++ b/X3Fuse/Views/SettingsView.swift
@@ -12,7 +12,6 @@ struct SettingsView: View {
   @State private var settings = ConversionSettings.shared
   @State private var loggingService = LoggingService.shared
   @EnvironmentObject private var updaterService: UpdaterService
-  @Environment(\.dismiss) private var dismiss
 
   var body: some View {
     NavigationStack {
@@ -252,21 +251,10 @@ struct SettingsView: View {
         }
       }
       .formStyle(GroupedFormStyle())
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button(LocalizationService.buttonCancel) {
-            dismiss()
-          }
-        }
-
-        ToolbarItem(placement: .confirmationAction) {
-          Button(LocalizationService.buttonDone) {
-            settings.saveSettings()
-            dismiss()
-          }
-          .buttonStyle(.borderedProminent)
-        }
-      }
+    }
+    .onDisappear {
+      // Auto-save settings when the window closes
+      settings.saveSettings()
     }
   }
 

--- a/X3Fuse/X3FuseApp.swift
+++ b/X3Fuse/X3FuseApp.swift
@@ -27,5 +27,11 @@ struct x3f_convertApp: App {
             MenuCommands()
         }
         .windowResizability(.contentSize)
+        
+        Settings {
+            SettingsView()
+                .environmentObject(updaterService)
+                .frame(width: 450, height: 700)
+        }
     }
 }


### PR DESCRIPTION
Refactor settings view to use a window instead of a popover. This resolves an issue where the settings view can prevent the app from quitting.