### PR TITLE
Publish Homebrew cask on release + notarize app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,29 @@ jobs:
             -exportPath Release \
             -exportOptionsPlist "export_options.plist"
 
+      - name: Notarize and staple app
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          echo -n "$APPLE_API_KEY_BASE64" | base64 --decode --output "$KEY_PATH"
+
+          # Notarization requires a zip/pkg payload; submit a zip of the exported app.
+          ditto -c -k --keepParent "Release/X3Fuse.app" "$RUNNER_TEMP/notarize.zip"
+
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+
+          # Staple the ticket onto the .app so the downstream .pkg and .zip ship it stapled.
+          xcrun stapler staple "Release/X3Fuse.app"
+          xcrun stapler validate "Release/X3Fuse.app"
+          spctl -a -vvv -t install "Release/X3Fuse.app" || true
+
       - name: Generate macOS installer
         uses: akiojin/generate-mac-installer-github-action@v1.0.4
         id: generate_installer
@@ -334,6 +357,7 @@ jobs:
     needs: archive
     outputs:
       new_version: ${{ steps.info.outputs.new_version }}
+      sha256: ${{ steps.sha.outputs.sha256 }}
     steps:
       - uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
@@ -371,6 +395,10 @@ jobs:
           mkdir Release
           mv artifacts/app/X3Fuse-App.zip Release/
           mv artifacts/app/X3Fuse-Installer.zip Release/
+
+      - name: Compute app sha256
+        id: sha
+        run: echo "sha256=$(shasum -a 256 Release/X3Fuse-App.zip | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Prepare Sparkle update creation
         run: |
@@ -424,6 +452,38 @@ jobs:
       - name: Create summary
         run: |
           echo "Release v${{ steps.info.outputs.new_version }} created." > $GITHUB_STEP_SUMMARY
+
+  homebrew:
+    name: Update Homebrew cask
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v5
+        with:
+          repository: sagwaco/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Bump cask version and sha256
+        env:
+          VERSION: ${{ needs.release.outputs.new_version }}
+          SHA: ${{ needs.release.outputs.sha256 }}
+        run: |
+          CASK="Casks/x3fuse.rb"
+          sed -i -E "s/^  version \"[^\"]*\"/  version \"$VERSION\"/" "$CASK"
+          sed -i -E "s/^  sha256 \"[^\"]*\"/  sha256 \"$SHA\"/" "$CASK"
+          echo "----- updated cask -----"
+          cat "$CASK"
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ needs.release.outputs.new_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/x3fuse.rb
+          git commit -m "x3fuse $VERSION" || { echo "No changes to commit"; exit 0; }
+          git push
 
   ending:
     name: Ending job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,10 @@ jobs:
       - name: Create ZIP archives
         run: |
           cd Release
-          zip -r X3Fuse-App.zip X3Fuse.app
+          # Use ditto (not `zip -r`) for the .app: it preserves the framework
+          # symlinks that plain zip would dereference, which would otherwise
+          # break the nested code signature and invalidate notarization.
+          ditto -c -k --keepParent X3Fuse.app X3Fuse-App.zip
           zip -r X3Fuse-Installer.zip X3Fuse.pkg
           cd ..
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,21 @@ If you have a Sigma Foveon camera from the Merrill and Quattro generations that 
 
 ## Installation
 
-### Option 1: Download Release
+### Option 1: Homebrew (recommended)
+
+```bash
+brew install --cask sagwaco/tap/x3fuse
+```
+
+Upgrade later with `brew upgrade --cask x3fuse` (the app also self-updates in-app via Sparkle).
+
+### Option 2: Download Release
 
 1. Download the latest .zip from the [Releases](https://github.com/sagwaco/x3fuse/releases) page
 2. Extract the .zip file and move the `X3Fuse.app` to your Applications folder.
 3. Launch `X3Fuse.app` from your Applications folder.
 
-### Option 2: Build from Source
+### Option 3: Build from Source
 
 1. Clone the repository:
    ```bash

--- a/README.md
+++ b/README.md
@@ -48,19 +48,20 @@ If you have a Sigma Foveon camera from the Merrill and Quattro generations that 
 
 ## Installation
 
-### Option 1: Homebrew (recommended)
+### Option 1: Download Release
+
+1. Download the latest .zip from the [Releases](https://github.com/sagwaco/x3fuse/releases) page
+2. Extract the .zip file and move the `X3Fuse.app` to your Applications folder.
+3. Launch `X3Fuse.app` from your Applications folder.
+
+
+### Option 2: Homebrew
 
 ```bash
 brew install --cask sagwaco/tap/x3fuse
 ```
 
 Upgrade later with `brew upgrade --cask x3fuse` (the app also self-updates in-app via Sparkle).
-
-### Option 2: Download Release
-
-1. Download the latest .zip from the [Releases](https://github.com/sagwaco/x3fuse/releases) page
-2. Extract the .zip file and move the `X3Fuse.app` to your Applications folder.
-3. Launch `X3Fuse.app` from your Applications folder.
 
 ### Option 3: Build from Source
 


### PR DESCRIPTION
## Summary
Integrates Homebrew distribution into the `/release` pipeline so users can `brew install --cask sagwaco/tap/x3fuse`, and adds notarization so cask installs open cleanly past Gatekeeper.

- **Notarize + staple** the exported app in the `archive` job (`notarytool submit --wait` then `stapler staple`), before the `.pkg`/`.zip` are built — so both ship a notarized, Gatekeeper-passing build. Homebrew quarantines cask installs by default, so this is required for a clean first launch.
- **`sha256` release-job output** (computed from the local zip, byte-identical to the uploaded asset).
- **New `homebrew` job** (`needs: release`) that checks out `sagwaco/homebrew-tap`, `sed`-bumps only the `version` and `sha256` lines in `Casks/x3fuse.rb`, and pushes to its `main`.
- README: adds Homebrew as the recommended install option.

The cask itself already lives in the tap: https://github.com/sagwaco/homebrew-tap/blob/main/Casks/x3fuse.rb (`auto_updates true` for Sparkle, `livecheck` on the existing appcast, `depends_on macos: :sonoma`, `zap`). `brew style` clean; online `brew audit` matched the sha256.

## ⚠️ Required before the next release
The notarize step is in the `archive` job, so **without these secrets any future `/release` will fail there**. Add to this repo's Actions secrets:
- `APPLE_API_KEY_BASE64`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID` — App Store Connect API key for `notarytool`
- `HOMEBREW_TAP_TOKEN` — fine-grained PAT with *Contents: write* on `sagwaco/homebrew-tap`

A `homebrew`-job failure won't block the release/merge (separate from the merge gate); a missing notarization secret will.

## Notes
- Direct-push (no PR) to the tap, per a personal-tap setup.
- Uses App Store Connect API key for notarytool; the Apple-ID + app-specific-password variant is an alternative if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)