### PR TITLE
Release v0.1.4 - Beta 1.1.4 (notarized build + Homebrew)

### DIFF
--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,3 +1,8 @@
+# 0.1.4 - Beta 1.1.4
+
+- The app is now notarized by Apple, so it launches without Gatekeeper warnings, and is installable via Homebrew with `brew install --cask sagwaco/tap/x3fuse`. No functional changes from 0.1.3.
+- Packaging-only release; see 0.1.3 for the latest features.
+
 # 0.1.3 - Beta 1.1.3
 
 - Add a denoise slider to control denoising intensity. The maximum value matches the previous default, the minimum is 1, and denoising can be toggled off entirely to disable it.

--- a/docs/Support/appcast.xml
+++ b/docs/Support/appcast.xml
@@ -7,6 +7,15 @@
         <language>en</language>
         <!-- Sparkle will populate this with release items -->
         <item>
+            <title>0.1.4</title>
+            <pubDate>Wed, 03 Jun 2026 22:38:46 +0000</pubDate>
+            <link>https://github.com/sagwaco/x3fuse/releases</link>
+            <sparkle:version>0.1.4</sparkle:version>
+            <sparkle:shortVersionString>0.1.4</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/sagwaco/x3fuse/releases/download/v0.1.4/X3Fuse-App.zip" length="56116579" type="application/octet-stream" sparkle:edSignature="En6ocqGKkuLXVxjx8fWZSeIji9FBkDmoxPFPuQiG8Eg3xq8J0IGkoIKVmsQBQw4CsEjychmfbfAKbBSGO55uDQ=="/>
+        </item>
+        <item>
             <title>0.1.3</title>
             <pubDate>Wed, 27 May 2026 19:09:17 +0000</pubDate>
             <link>https://github.com/sagwaco/x3fuse/releases</link>
@@ -23,15 +32,6 @@
             <sparkle:shortVersionString>0.1.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/sagwaco/x3fuse/releases/download/v0.1.2/X3Fuse-App.zip" length="58213558" type="application/octet-stream" sparkle:edSignature="3fKLc1TbEEU9Y6AgjL3FRfHPVyLxMgZts6PYSV+o/l2uRHa/D5RtEF1uVWk+/ZEilEBXZxc5v9xOawLL7yHsAQ=="/>
-        </item>
-        <item>
-            <title>0.1.1</title>
-            <pubDate>Fri, 15 Aug 2025 16:06:16 +0000</pubDate>
-            <link>https://github.com/sagwaco/x3fuse/releases</link>
-            <sparkle:version>0.1.1</sparkle:version>
-            <sparkle:shortVersionString>0.1.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/sagwaco/x3fuse/releases/download/v0.1.1/X3Fuse-App.zip" length="60087750" type="application/octet-stream" sparkle:edSignature="V+S7G7O/ifLZ/5gc2m+z2JC/Gb5ULQgq1Q62QI+DAKu0K4jN/WRHQ0TD7kw10H7pGeKUdWJeZIWG1qt8PH7jDg=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Packaging-only release. No functional changes from 0.1.3.

Purpose: publish a **notarized**, `ditto`-zipped build (the first release to go through the new notarization + ditto pipeline) and make it installable via the Homebrew cask. The original v0.1.3 zip was non-notarized and had a broken-symlink signature, so `brew install --cask` couldn't pass Gatekeeper.

On `/release` the pipeline will:
- build → notarize + staple → `ditto`-zip `X3Fuse-App.zip`
- publish GitHub Release `v0.1.4` + regenerate the Sparkle appcast
- auto-bump `sagwaco/homebrew-tap` `Casks/x3fuse.rb` to 0.1.4 + new sha256

🤖 Generated with [Claude Code](https://claude.com/claude-code)