### PR TITLE
docs: add release notes

### DIFF
--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,3 +1,11 @@
+# 0.1.5 - Beta 1.1.5
+
+- Update the core converter to x3fuse-core 0.1.2, improving compatibility of converted DNGs (including compressed DNGs) with software powered by Apple RAW and LibRaw, and improving Capture One compatibility for Merrill-generation files.
+- Fix highlights clipping prematurely near white on some files, caused by DigitalISOGain scaling during preprocessing.
+- Add Spanish (es) localization.
+- Fix the denoise slider labels in Settings showing raw localization keys instead of translated text.
+- The in-app update prompt now displays release notes, so you can see what changed before updating.
+
 # 0.1.4 - Beta 1.1.4
 
 - The app is now notarized by Apple, so it launches without Gatekeeper warnings, and is installable via Homebrew with `brew install --cask sagwaco/tap/x3fuse`. No functional changes from 0.1.3.

--- a/docs/Support/appcast.xml
+++ b/docs/Support/appcast.xml
@@ -7,6 +7,16 @@
         <language>en</language>
         <!-- Sparkle will populate this with release items -->
         <item>
+            <title>0.1.5</title>
+            <pubDate>Mon, 15 Jun 2026 04:33:43 +0000</pubDate>
+            <link>https://github.com/sagwaco/x3fuse/releases</link>
+            <sparkle:version>0.1.5</sparkle:version>
+            <sparkle:shortVersionString>0.1.5</sparkle:shortVersionString>
+            <description><![CDATA[<style>body{font:13px/1.5 -apple-system,BlinkMacSystemFont,'Helvetica Neue',sans-serif;color:#1d1d1f;margin:0;padding:2px}h3{font-size:13px;font-weight:600;margin:0 0 6px}ul{margin:0;padding-left:18px}li{margin:0 0 5px}code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;background:rgba(127,127,127,.15);padding:1px 4px;border-radius:3px}@media(prefers-color-scheme:dark){body{color:#f5f5f7}}</style><h3>Beta 1.1.5</h3><ul><li>Update the core converter to x3fuse-core 0.1.2, improving compatibility of converted DNGs (including compressed DNGs) with software powered by Apple RAW and LibRaw, and improving Capture One compatibility for Merrill-generation files.</li><li>Fix highlights clipping prematurely near white on some files, caused by DigitalISOGain scaling during preprocessing.</li><li>Add Spanish (es) localization.</li><li>Fix the denoise slider labels in Settings showing raw localization keys instead of translated text.</li><li>The in-app update prompt now displays release notes, so you can see what changed before updating.</li></ul>]]></description>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/sagwaco/x3fuse/releases/download/v0.1.5/X3Fuse-App.zip" length="54864436" type="application/octet-stream" sparkle:edSignature="aO1B+x9mNnMrtIcp8jz88g4VX9CP8vWYhFKIZRrk3SGLLE7FbPf7njZ/XUR+VTioas3XrO9nsswTxicV2X3NAA=="/>
+        </item>
+        <item>
             <title>0.1.4</title>
             <pubDate>Wed, 03 Jun 2026 22:38:46 +0000</pubDate>
             <link>https://github.com/sagwaco/x3fuse/releases</link>
@@ -25,16 +35,6 @@
             <description><![CDATA[<style>body{font:13px/1.5 -apple-system,BlinkMacSystemFont,'Helvetica Neue',sans-serif;color:#1d1d1f;margin:0;padding:2px}h3{font-size:13px;font-weight:600;margin:0 0 6px}ul{margin:0;padding-left:18px}li{margin:0 0 5px}code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;background:rgba(127,127,127,.15);padding:1px 4px;border-radius:3px}@media(prefers-color-scheme:dark){body{color:#f5f5f7}}</style><h3>Beta 1.1.3</h3><ul><li>Add a denoise slider to control denoising intensity. The maximum value matches the previous default, the minimum is 1, and denoising can be toggled off entirely to disable it.</li></ul>]]></description>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://github.com/sagwaco/x3fuse/releases/download/v0.1.3/X3Fuse-App.zip" length="58222290" type="application/octet-stream" sparkle:edSignature="Tj0TZM0iuk7cYccXfuzmgGfxXauXHrHtJX7UhmwJA4i/s5XM6ZN38Q7LTLdKzGJ+mU+UCHx9m+hHSU1HoQG/Cg=="/>
-        </item>
-        <item>
-            <title>0.1.2</title>
-            <pubDate>Tue, 26 May 2026 03:03:18 +0000</pubDate>
-            <link>https://github.com/sagwaco/x3fuse/releases</link>
-            <sparkle:version>0.1.2</sparkle:version>
-            <sparkle:shortVersionString>0.1.2</sparkle:shortVersionString>
-            <description><![CDATA[<style>body{font:13px/1.5 -apple-system,BlinkMacSystemFont,'Helvetica Neue',sans-serif;color:#1d1d1f;margin:0;padding:2px}h3{font-size:13px;font-weight:600;margin:0 0 6px}ul{margin:0;padding-left:18px}li{margin:0 0 5px}code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;background:rgba(127,127,127,.15);padding:1px 4px;border-radius:3px}@media(prefers-color-scheme:dark){body{color:#f5f5f7}}</style><h3>Beta 1.1.2</h3><ul><li>Add highlight recovery option for Merrill DNGs, which prevents string hue shifts in extremely overexposed areas. This setting has only been tested to work with Adobe Camera RAW and LibRaw.</li><li>Add option to apply a flat cineon-like tone curve to tiffs.</li></ul>]]></description>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/sagwaco/x3fuse/releases/download/v0.1.2/X3Fuse-App.zip" length="58213558" type="application/octet-stream" sparkle:edSignature="3fKLc1TbEEU9Y6AgjL3FRfHPVyLxMgZts6PYSV+o/l2uRHa/D5RtEF1uVWk+/ZEilEBXZxc5v9xOawLL7yHsAQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
### Release 0.1.5 - Beta 1.1.5

- Update the core converter to x3fuse-core 0.1.2, improving compatibility of converted DNGs (including compressed DNGs) with software powered by Apple RAW and LibRaw, and improving Capture One compatibility for Merrill-generation files.
- Fix highlights clipping prematurely near white on some files, caused by DigitalISOGain scaling during preprocessing.
- Add Spanish (es) localization.
- Fix the denoise slider labels in Settings showing raw localization keys instead of translated text.
- The in-app update prompt now displays release notes, so you can see what changed before updating.